### PR TITLE
modify:TaoBaoAPIClient.retry_sub_codes will extend from default value

### DIFF
--- a/taobaopy/taobao.py
+++ b/taobaopy/taobao.py
@@ -287,7 +287,7 @@ class TaoBaoAPIClient(object):
         self.get = HttpObject(self)
         self.post = HttpObject(self)
         self.upload = HttpObject(self)
-        self.retry_sub_codes = retry_sub_codes if retry_sub_codes else RETRY_SUB_CODES
+        self.retry_sub_codes = RETRY_SUB_CODES | (retry_sub_codes or set())
         self.retry_count = retry_count
         self.kw = kw
 


### PR DESCRIPTION
我认为taobaopy的使用者不应该关注类似于timeout这种通用的、每个接口都可能出现的错误，而目前的情况下如果使用者想要自定义retry_sub_codes时，必须要在自定义的retry_sub_codes里面加入所有的需要处理的错误（包含timeout之类的错误）。我认为这样是不合理的。我认为对于retry_sub_codes这项配置来说，更合理的方式应该是用户自定义的配置作为默认配置的扩展。